### PR TITLE
Adapt go.mod and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ It also allows you to mount a pseudo file system containing (a subset of) your c
 
 ### From soucre: 
 
-Make sure you have [go](https://golang.org/doc/install) installed, then run:
+Make sure you have [go](https://golang.org/doc/install) installed, then change to the $GOPATH directory
+(default is ~/go) and run:
 
-```
-go get -u github.com/unprofession-al/scum
+```bash
+go install github.com/unprofession-al/scum@latest
 ```
 
 ### Usage

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module scum
+module github.com/hansmannj/scum
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hansmannj/scum
+module scum github.com/unprofession-al/scum
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module scum github.com/unprofession-al/scum
+module github.com/unprofession-al/scum
 
 go 1.13
 


### PR DESCRIPTION
As the use of go get is deprecated (https://go.dev/doc/go-get-install-deprecation),
using go install is now recommended. This currently throws the following:
`module declares its path as: scum but was required as: github.com/unprofession-al/scum.`
This PR should fix this by adapting go.mod and also updates the README.md